### PR TITLE
Add config as text extension

### DIFF
--- a/src/EmptyFiles/FileExtensions.cs
+++ b/src/EmptyFiles/FileExtensions.cs
@@ -130,6 +130,7 @@ public static class FileExtensions
         "coffee",
         "coffeekup",
         "conf",
+        "config",
         "cp",
         "cpp",
         "cpt",


### PR DESCRIPTION
`.config` is a textual configuration file in dotnet world - let's recognize it so