### PR TITLE
Add .il text extension

### DIFF
--- a/src/EmptyFiles/FileExtensions.cs
+++ b/src/EmptyFiles/FileExtensions.cs
@@ -215,6 +215,7 @@ public static class FileExtensions
         "htpasswd",
         "hxx",
         "iced",
+        "il",
         "iml",
         "inc",
         "inf",


### PR DESCRIPTION
I noticed that [resharper-verify](https://github.com/matkoch/resharper-verify) refuses to open a diff when the snapshot is an `il` file. 

This is probably because of [this line](https://github.com/matkoch/resharper-verify/blob/63a6f81660e505451964020c58c3a7c768972572/src/dotnet/ReSharperPlugin.Verify/VerifyCompareAction.cs#L47). I'm not sure if this PR will solve this particular issue for the next build of resharper-verify, but it won't hurt.

This relates to https://github.com/VerifyTests/Verify.ICSharpCode.Decompiler/pull/403