### PR TITLE
Add .gv (DOT graph description language) to the known text extensions

### DIFF
--- a/src/EmptyFiles/FileExtensions.cs
+++ b/src/EmptyFiles/FileExtensions.cs
@@ -192,6 +192,7 @@ public static class FileExtensions
         ".groupproj",
         ".grunit",
         ".gtmpl",
+        ".gv",
         ".gvimrc",
         ".h",
         ".haml",


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/DOT_(graph_description_language) and https://forum.graphviz.org/t/what-is-the-file-extension-for-dot-file/35

Somehow related to https://github.com/VerifyTests/Verify/pull/1157 ;-)
