### PR TITLE
Add '.toml' to textExtensions

### DIFF
--- a/src/EmptyFiles/FileExtensions.cs
+++ b/src/EmptyFiles/FileExtensions.cs
@@ -400,6 +400,7 @@ public static class FileExtensions
             ".tmLanguage",
             ".tmpl",
             ".tmTheme",
+            ".toml",
             ".tpl",
             ".ts",
             ".tsv",


### PR DESCRIPTION
I tried out Verify for the first time today and stumbled upon this absence in the form of a missing diff window for a .toml, hopefully this change is sufficient to achieve the desired effect.