### PR TITLE
Fix correctness and perf issues across the lookup and extraction paths

### DIFF
--- a/src/EmptyFiles/AllFiles.cs
+++ b/src/EmptyFiles/AllFiles.cs
@@ -38,7 +38,7 @@ public static class AllFiles
         sheets = AddCategory(sheetExtensions, Category.Sheet);
         slides = AddCategory(slideExtensions, Category.Slide);
         binary = AddCategory(binaryExtensions, Category.Binary);
-        var all = new Dictionary<string, EmptyFile>();
+        var all = new Dictionary<string, EmptyFile>(StringComparer.OrdinalIgnoreCase);
         Append(archives);
         Append(documents);
         Append(images);
@@ -46,7 +46,7 @@ public static class AllFiles
         Append(slides);
         Append(binary);
 
-        files = all.ToFrozenDictionary();
+        files = all.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
         void Append(FrozenDictionary<string, EmptyFile> files)
         {
@@ -59,7 +59,7 @@ public static class AllFiles
 
     static FrozenDictionary<string, EmptyFile> AddCategory(FrozenSet<string> extensions, Category category)
     {
-        Dictionary<string, EmptyFile> items = [];
+        Dictionary<string, EmptyFile> items = new(StringComparer.OrdinalIgnoreCase);
         var categoryName = category
             .ToString()
             .ToLowerInvariant();
@@ -69,14 +69,27 @@ public static class AllFiles
             items[extension] = EmptyFile.Embedded(category, extension, resourceName);
         }
 
-        return items.ToFrozenDictionary();
+        return items.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     static readonly Lazy<string> extractDirectory = new(
         () =>
         {
+            // AssemblyVersion and FileVersion are both pinned (1.0.0), so use the
+            // informational version, which tracks the package version, to keep
+            // extracted templates isolated per release. Strip any "+sha" suffix
+            // appended by source control integration.
             var assembly = typeof(AllFiles).Assembly;
-            var version = assembly.GetName().Version?.ToString() ?? "unknown";
+            var informational = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion;
+            var version = "unknown";
+            if (informational != null)
+            {
+                var plusIndex = informational.IndexOf('+');
+                version = plusIndex == -1 ? informational : informational[..plusIndex];
+            }
+
             return Path.Combine(Path.GetTempPath(), "EmptyFiles", version);
         });
 
@@ -84,32 +97,30 @@ public static class AllFiles
 
     static void ExtractAll(string directory)
     {
-        var assembly = typeof(AllFiles).Assembly;
-        ExtractCategory(assembly, directory, "archive", archiveExtensions);
-        ExtractCategory(assembly, directory, "binary", binaryExtensions);
-        ExtractCategory(assembly, directory, "document", documentExtensions);
-        ExtractCategory(assembly, directory, "image", imageExtensions);
-        ExtractCategory(assembly, directory, "sheet", sheetExtensions);
-        ExtractCategory(assembly, directory, "slide", slideExtensions);
+        ExtractCategory(directory, "archive", archives);
+        ExtractCategory(directory, "binary", binary);
+        ExtractCategory(directory, "document", documents);
+        ExtractCategory(directory, "image", images);
+        ExtractCategory(directory, "sheet", sheets);
+        ExtractCategory(directory, "slide", slides);
     }
 
-    static void ExtractCategory(Assembly assembly, string root, string categoryName, FrozenSet<string> extensions)
+    static void ExtractCategory(string root, string categoryName, FrozenDictionary<string, EmptyFile> items)
     {
         var categoryDirectory = Path.Combine(root, categoryName);
         Directory.CreateDirectory(categoryDirectory);
-        foreach (var extension in extensions)
+        foreach (var emptyFile in items.Values)
         {
-            var resourceName = $"EmptyFiles.{categoryName}.empty{extension}";
-            using var resource = assembly.GetManifestResourceStream(resourceName) ??
-                                 throw new($"Embedded resource not found: {resourceName}");
-            var target = Path.Combine(categoryDirectory, $"empty{extension}");
-            if (File.Exists(target) && new FileInfo(target).Length == resource.Length)
+            using var resource = emptyFile.OpenRead();
+            var target = Path.Combine(categoryDirectory, $"empty{emptyFile.Extension}");
+            if (File.Exists(target) &&
+                new FileInfo(target).Length == resource.Length)
             {
                 continue;
             }
 
-            using var file = File.Create(target);
-            resource.CopyTo(file);
+            using var fileStream = File.Create(target);
+            resource.CopyTo(fileStream);
         }
     }
 
@@ -149,21 +160,27 @@ public static class AllFiles
                 throw new($"Unknown category: {category}");
         }
 
+        var mergedFiles = new Dictionary<string, EmptyFile>(files, StringComparer.OrdinalIgnoreCase)
+        {
+            [extension] = emptyFile
+        };
+        files = mergedFiles.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
         void Init(ref FrozenDictionary<string, EmptyFile> emptyFiles, ref FrozenSet<string> extensions)
         {
-            var tempDictionary = new Dictionary<string, EmptyFile>();
+            var tempDictionary = new Dictionary<string, EmptyFile>(StringComparer.OrdinalIgnoreCase);
             foreach (var (key, value) in emptyFiles)
             {
                 tempDictionary[key] = value;
             }
 
             tempDictionary[extension] = emptyFile;
-            emptyFiles = tempDictionary.ToFrozenDictionary();
-            var tempSet = new HashSet<string>(extensions)
+            emptyFiles = tempDictionary.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+            var tempSet = new HashSet<string>(extensions, StringComparer.OrdinalIgnoreCase)
             {
                 extension
             };
-            extensions = tempSet.ToFrozenSet();
+            extensions = tempSet.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
         }
     }
 
@@ -189,7 +206,8 @@ public static class AllFiles
         ".tar",
         ".xz",
         ".zip"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<string> DocumentPaths => documents.Values.Select(_ => _.Path);
 
@@ -201,7 +219,8 @@ public static class AllFiles
         ".odt",
         ".pdf",
         ".rtf"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<string> ImagePaths => images.Values.Select(_ => _.Path);
 
@@ -239,7 +258,8 @@ public static class AllFiles
         ".wdp",
         ".webp",
         ".wmp"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<string> SheetPaths => sheets.Values.Select(_ => _.Path);
 
@@ -249,7 +269,8 @@ public static class AllFiles
     [
         ".ods",
         ".xlsx"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<string> SlidePaths => slides.Values.Select(_ => _.Path);
 
@@ -259,7 +280,8 @@ public static class AllFiles
     [
         ".odp",
         ".pptx"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static IEnumerable<string> BinaryPaths => binary.Values.Select(_ => _.Path);
 
@@ -268,7 +290,8 @@ public static class AllFiles
     static FrozenSet<string> binaryExtensions = FrozenSet.ToFrozenSet(
     [
         ".bin"
-    ]);
+    ],
+    StringComparer.OrdinalIgnoreCase);
 
     public static bool IsEmptyFile(string path)
     {
@@ -319,6 +342,11 @@ public static class AllFiles
         Guard.AgainstNullOrEmpty(path);
         var extension = Path.GetExtension(path);
 
+        if (extension.Length == 0)
+        {
+            return false;
+        }
+
         if (useEmptyStringForTextFiles &&
             FileExtensions.IsTextExtension(extension))
         {
@@ -351,6 +379,12 @@ public static class AllFiles
 
     public static bool TryGetPathFor(string extension, [NotNullWhen(true)] out string? path)
     {
+        if (extension.Length > 0 &&
+            extension[0] != '.')
+        {
+            extension = $".{extension}";
+        }
+
         if (files.TryGetValue(extension, out var emptyFile))
         {
             path = emptyFile.Path;

--- a/src/EmptyFiles/ContentTypes.cs
+++ b/src/EmptyFiles/ContentTypes.cs
@@ -235,7 +235,7 @@ public static class ContentTypes
             "image/bmp", "bmp"
         },
         {
-            "image/heic", ".heic"
+            "image/heic", "heic"
         },
         {
             "image/heic-sequence", "heics"

--- a/src/EmptyFiles/EmptyFile.cs
+++ b/src/EmptyFiles/EmptyFile.cs
@@ -27,6 +27,7 @@ public class EmptyFile
     string? path;
     DateTime lastWriteTime;
     bool extracted;
+    readonly bool embedded;
     readonly object sync = new();
 
     internal static EmptyFile Embedded(Category category, string extension, string resourceName) =>
@@ -37,6 +38,7 @@ public class EmptyFile
         Category = category;
         Extension = extension;
         ResourceName = resourceName;
+        embedded = true;
     }
 
     public EmptyFile(string path, in DateTime lastWriteTime, in Category category)
@@ -68,13 +70,11 @@ public class EmptyFile
             var directory = System.IO.Path.Combine(AllFiles.ExtractDirectory, categoryName);
             Directory.CreateDirectory(directory);
             var target = System.IO.Path.Combine(directory, $"empty{Extension}");
-            var assembly = typeof(EmptyFile).Assembly;
-            using var resource = assembly.GetManifestResourceStream(ResourceName) ??
-                                 throw new($"Embedded resource not found: {ResourceName}");
-            if (!File.Exists(target) || new FileInfo(target).Length != resource.Length)
+            using var resource = OpenRead();
+            if (!File.Exists(target) ||
+                new FileInfo(target).Length != resource.Length)
             {
-                using var fileStream = File.Create(target);
-                resource.CopyTo(fileStream);
+                ExtractTo(directory, target, resource);
             }
 
             path = target;
@@ -83,8 +83,45 @@ public class EmptyFile
         }
     }
 
+    // Extract via a unique temp file then move into place, so that parallel
+    // test processes sharing the temp directory cannot observe or write a
+    // partially written file. A concurrent process winning the race is treated
+    // as success, since every process writes byte-identical content.
+    static void ExtractTo(string directory, string target, Stream resource)
+    {
+        var temp = System.IO.Path.Combine(directory, $"{Guid.NewGuid():N}.tmp");
+        try
+        {
+            using (var fileStream = File.Create(temp))
+            {
+                resource.CopyTo(fileStream);
+            }
+
+            try
+            {
+                File.Move(temp, target);
+            }
+            catch (IOException) when (File.Exists(target))
+            {
+                // Another process published the file first.
+            }
+        }
+        finally
+        {
+            if (File.Exists(temp))
+            {
+                File.Delete(temp);
+            }
+        }
+    }
+
     public Stream OpenRead()
     {
+        if (!embedded)
+        {
+            return File.OpenRead(Path);
+        }
+
         var assembly = typeof(EmptyFile).Assembly;
         return assembly.GetManifestResourceStream(ResourceName) ??
                throw new($"Embedded resource not found: {ResourceName}");

--- a/src/EmptyFiles/FileExtensions.cs
+++ b/src/EmptyFiles/FileExtensions.cs
@@ -4,13 +4,43 @@ public static class FileExtensions
 {
     public static bool IsTextExtension(string extension)
     {
-        extension = Guard.ValidExtension(extension);
+        if (extension.Length == 0)
+        {
+            throw new ArgumentNullException(nameof(extension));
+        }
 
-        return textExtensions.Contains(extension);
+        // Avoid allocating a dotted copy for the common dotless input (the form
+        // Verify passes on its per-target hot path) by keeping a parallel set.
+        if (extension[0] == '.')
+        {
+            return textExtensions.Contains(extension);
+        }
+
+        return textExtensionsWithoutDot.Contains(extension);
     }
 
-    public static bool IsTextExtension(CharSpan extension) =>
-        IsTextExtension(extension.ToString());
+    public static bool IsTextExtension(CharSpan extension)
+    {
+#if NET9_0_OR_GREATER
+        if (extension.Length == 0)
+        {
+            throw new ArgumentNullException(nameof(extension));
+        }
+
+        if (extension[0] == '.')
+        {
+            return textExtensions
+                .GetAlternateLookup<CharSpan>()
+                .Contains(extension);
+        }
+
+        return textExtensionsWithoutDot
+            .GetAlternateLookup<CharSpan>()
+            .Contains(extension);
+#else
+        return IsTextExtension(extension.ToString());
+#endif
+    }
 
     public static bool IsTextFile(string path) =>
         IsTextFile(path.AsSpan());
@@ -38,9 +68,10 @@ public static class FileExtensions
     public static void RemoveTextExtension(string extension)
     {
         extension = Guard.ValidExtension(extension);
-        var copy = new HashSet<string>(textExtensions);
+        var copy = new HashSet<string>(textExtensions, StringComparer.OrdinalIgnoreCase);
         copy.Remove(extension);
-        textExtensions = copy.ToFrozenSet();
+        textExtensions = copy.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        textExtensionsWithoutDot = BuildWithoutDot();
     }
 
     public static void RemoveTextExtension(CharSpan extension) =>
@@ -65,11 +96,12 @@ public static class FileExtensions
     public static void AddTextExtension(string extension)
     {
         extension = Guard.ValidExtension(extension);
-        var copy = new HashSet<string>(textExtensions)
+        var copy = new HashSet<string>(textExtensions, StringComparer.OrdinalIgnoreCase)
         {
             extension
         };
-        textExtensions = copy.ToFrozenSet();
+        textExtensions = copy.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        textExtensionsWithoutDot = BuildWithoutDot();
     }
 
     public static void AddTextExtension(CharSpan extension) =>
@@ -97,7 +129,7 @@ public static class FileExtensions
     static List<IsTextFile> textFileConventions = [];
 
     //From https://github.com/sindresorhus/text-extensions/blob/master/text-extensions.json
-    static IReadOnlyCollection<string> textExtensions = new HashSet<string>
+    static FrozenSet<string> textExtensions = new HashSet<string>
         {
             ".ada",
             ".adb",
@@ -442,7 +474,16 @@ public static class FileExtensions
             ".zsh",
             ".zshrc"
         }
-        .ToFrozenSet();
+        .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    // Parallel set of the same extensions without the leading dot, so that the
+    // dotless overload of IsTextExtension can look up without allocating.
+    static FrozenSet<string> textExtensionsWithoutDot = BuildWithoutDot();
+
+    static FrozenSet<string> BuildWithoutDot() =>
+        textExtensions
+            .Select(_ => _[1..])
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     public static IReadOnlyCollection<string> TextExtensions => textExtensions;
 

--- a/src/EmptyFiles/Guard.cs
+++ b/src/EmptyFiles/Guard.cs
@@ -2,7 +2,7 @@ static class Guard
 {
     public static void FileExists(string path, [CallerArgumentExpression("path")] string argumentName = "")
     {
-        AgainstNullOrEmpty(argumentName, path);
+        AgainstNullOrEmpty(path, argumentName);
         if (!File.Exists(path))
         {
             throw new ArgumentException($"File not found. Path: {path}");

--- a/src/Tests/ContentTypesTests.cs
+++ b/src/Tests/ContentTypesTests.cs
@@ -25,6 +25,18 @@
     }
 
     [Test]
+    public void Heic()
+    {
+        // The extension must not carry a leading dot, unlike every other mapping.
+        True(ContentTypes.TryGetExtension("image/heic", out var extension));
+        AreEqual("heic", extension);
+        True(ContentTypes.TryGetMediaType("heic", out var media));
+        AreEqual("image/heic", media);
+        True(ContentTypes.TryGetMediaType(".heic", out media));
+        AreEqual("image/heic", media);
+    }
+
+    [Test]
     public void IsText()
     {
         True(ContentTypes.IsText("application/json", out var extension));

--- a/src/Tests/ExtensionsTests.cs
+++ b/src/Tests/ExtensionsTests.cs
@@ -33,6 +33,48 @@
     #endregion
 
     [Test]
+    public void IsTextExtension_CaseInsensitive()
+    {
+        True(FileExtensions.IsTextExtension(".TXT"));
+        True(FileExtensions.IsTextExtension("TXT"));
+        True(FileExtensions.IsTextExtension(".Txt"));
+        True(FileExtensions.IsTextFile("FILE.TXT"));
+        True(FileExtensions.IsTextFile("README.MD"));
+    }
+
+    [Test]
+    public void IsTextExtension_Span()
+    {
+        True(FileExtensions.IsTextExtension(".txt".AsSpan()));
+        True(FileExtensions.IsTextExtension("txt".AsSpan()));
+        True(FileExtensions.IsTextExtension("TXT".AsSpan()));
+        False(FileExtensions.IsTextExtension("bin".AsSpan()));
+    }
+
+    [Test]
+    public void AddRemoveTextExtension_CaseInsensitive()
+    {
+        FileExtensions.AddTextExtension(".CaseExt");
+        try
+        {
+            True(FileExtensions.IsTextExtension(".caseext"));
+            True(FileExtensions.IsTextExtension("CASEEXT"));
+            True(FileExtensions.IsTextExtension("caseext".AsSpan()));
+        }
+        finally
+        {
+            FileExtensions.RemoveTextExtension(".CASEEXT");
+        }
+
+        False(FileExtensions.IsTextExtension(".caseext"));
+        False(FileExtensions.IsTextExtension("caseext"));
+    }
+
+    [Test]
+    public void IsTextExtension_Empty_Throws() =>
+        Throws<ArgumentNullException>(() => FileExtensions.IsTextExtension(""));
+
+    [Test]
     public void IsTextLegacy()
     {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -1,6 +1,121 @@
 ﻿[TestFixture]
 public class Tests
 {
+    // UseFile mutates global state with no unregister, so register once for the
+    // whole fixture and keep the backing file on disk until every test (notably
+    // WriteAllTo, which reads it) has run.
+    static string useFileTarget = null!;
+
+    [OneTimeSetUp]
+    public void RegisterUseFile()
+    {
+        useFileTarget = Path.Combine(Path.GetTempPath(), $"EmptyFilesUseFile{Guid.NewGuid():N}.usefileext");
+        File.WriteAllText(useFileTarget, "content");
+        AllFiles.UseFile(Category.Document, useFileTarget);
+    }
+
+    [OneTimeTearDown]
+    public void CleanupUseFile() =>
+        File.Delete(useFileTarget);
+
+    [Test]
+    public void UseFile_UpdatesLookups()
+    {
+        True(AllFiles.DocumentPaths.Contains(useFileTarget));
+
+        // Regression: the merged Files dictionary and every lookup built on it
+        // must see the registered file, not just the per-category dictionary.
+        True(AllFiles.Files.ContainsKey(".usefileext"));
+        AreEqual(useFileTarget, AllFiles.GetPathFor(".usefileext"));
+        True(AllFiles.TryGetPathFor("usefileext", out var path));
+        AreEqual(useFileTarget, path);
+        True(AllFiles.IsEmptyFile(useFileTarget));
+
+        // Lookups are case-insensitive.
+        AreEqual(useFileTarget, AllFiles.GetPathFor(".USEFILEEXT"));
+        True(AllFiles.TryGetPathFor("USEFILEEXT", out _));
+    }
+
+    [Test]
+    public void TryCreateFile_extensionless()
+    {
+        False(AllFiles.TryCreateFile("Dockerfile", useEmptyStringForTextFiles: true));
+        False(AllFiles.TryCreateFile("LICENSE"));
+    }
+
+    [Test]
+    public void GetPathFor_caseInsensitive()
+    {
+        NotNull(AllFiles.GetPathFor(".PNG"));
+        NotNull(AllFiles.GetPathFor("PNG"));
+    }
+
+    [Test]
+    public void TryGetPathFor_normalizesDotlessAndCase()
+    {
+        True(AllFiles.TryGetPathFor("png", out var path));
+        NotNull(path);
+        True(AllFiles.TryGetPathFor(".png", out _));
+        True(AllFiles.TryGetPathFor("PNG", out _));
+        True(AllFiles.TryGetPathFor(".PNG", out _));
+    }
+
+    [Test]
+    public void IsEmptyFile_empty_throwsArgumentNull()
+    {
+        var exception = Throws<ArgumentNullException>(() => AllFiles.IsEmptyFile(""));
+        AreEqual("path", exception!.ParamName);
+    }
+
+    [Test]
+    public void ExtractDirectory_isVersionIsolated()
+    {
+        var path = AllFiles.GetPathFor(".png");
+        var versionDirectory = new DirectoryInfo(Path.GetDirectoryName(path)!).Parent!;
+        AreEqual("EmptyFiles", versionDirectory.Parent!.Name);
+
+        // AssemblyVersion and FileVersion are both pinned to 1.0.0; extraction
+        // must be keyed on the package (informational) version instead.
+        var assemblyVersion = typeof(AllFiles).Assembly.GetName().Version!.ToString();
+        AreNotEqual(assemblyVersion, versionDirectory.Name);
+        AreNotEqual("1.0.0", versionDirectory.Name);
+        AreNotEqual("unknown", versionDirectory.Name);
+    }
+
+    [Test]
+    public void Extraction_leavesNoTempFiles()
+    {
+        var path = AllFiles.GetPathFor(".png");
+        True(File.Exists(path));
+        var directory = Path.GetDirectoryName(path)!;
+        IsEmpty(Directory.GetFiles(directory, "*.tmp"));
+    }
+
+    [Test]
+    public void EmptyFile_OpenRead_userFile()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"EmptyFileOpenRead{Guid.NewGuid():N}.dat");
+        File.WriteAllText(file, "hello");
+        try
+        {
+            var emptyFile = new EmptyFile(file, File.GetLastWriteTime(file), Category.Binary);
+            using var stream = emptyFile.OpenRead();
+            using var reader = new StreamReader(stream);
+            AreEqual("hello", reader.ReadToEnd());
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Test]
+    public void EmptyFile_OpenRead_embedded()
+    {
+        using var stream = AllFiles.Images[".png"].OpenRead();
+        True(stream.Length > 0);
+    }
+
     [Test]
     public void CreateFile_overwrite_binary()
     {


### PR DESCRIPTION
- UseFile: rebuild the merged Files dictionary so GetPathFor, TryCreateFile, IsEmptyFile and Files see registered files again (regression from the Frozen refactor)
- TryCreateFile: return false for extensionless paths instead of throwing ArgumentNullException
- ContentTypes: map image/heic to "heic" (drop stray leading dot)
- Extraction: key the temp directory on InformationalVersion instead of the pinned AssemblyVersion/FileVersion (1.0.0), so templates are isolated per release
- Extraction: write to a unique temp file then move into place, so parallel processes sharing the temp dir cannot race File.Create
- OpenRead reads user-registered files from disk; WriteAllTo enumerates EmptyFile instances so custom registrations extract correctly
- Extension lookups now use OrdinalIgnoreCase, matching ContentTypes
- TryGetPathFor normalizes dotless extensions like GetPathFor
- Guard.FileExists: pass arguments in the correct order
- IsTextExtension: back with a FrozenSet plus a dotless companion set to avoid per-call allocation on the dotless hot path; use GetAlternateLookup on the span overload for net9+